### PR TITLE
修复动态修改repl-backlog-size时rvs内存越界的bug

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -936,6 +936,7 @@ void configSetCommand(redisClient *c) {
         ll = memtoll(o->ptr,&err);
         if (err || ll < 0) goto badfmt;
         resizeReplicationBacklog(ll);
+        resizeRvsBacklog(ll);
     } else if (!strcasecmp(c->argv[2]->ptr,"repl-backlog-ttl")) {
         if (getLongLongFromObject(o,&ll) == REDIS_ERR || ll < 0) goto badfmt;
         server.repl_backlog_time_limit = ll;

--- a/src/redis.h
+++ b/src/redis.h
@@ -1209,6 +1209,7 @@ char *replicationGetSlaveName(redisClient *c);
 long long getPsyncInitialOffset(void);
 int replicationSetupSlaveForFullResync(redisClient *slave, long long offset);
 void replicationFeedRvsBacklog(void *ptr, size_t len);
+void resizeRvsBacklog(long long newsize);
 
 /* Generic persistence functions */
 void startLoading(FILE *fp);

--- a/src/replication.c
+++ b/src/replication.c
@@ -110,6 +110,21 @@ void replicationFeedRvsBacklog(void *ptr, size_t len) {
                              server.rvs_backlog_histlen + 1;
 }
 
+void resizeRvsBacklog(long long newsize)
+{
+    if (newsize < REDIS_REPL_BACKLOG_MIN_SIZE) {
+        newsize = REDIS_REPL_BACKLOG_MIN_SIZE;
+    }
+
+    if (server.rvs_backlog != NULL) {
+        zfree(server.rvs_backlog);
+        server.rvs_backlog = zmalloc(newsize);
+        server.rvs_backlog_histlen = 0;
+        server.rvs_backlog_idx = 0;
+        server.rvs_fregment_len = 0;
+    }
+}
+
 void createReplicationBacklog(void) {
     redisAssert(server.repl_backlog == NULL);
     server.repl_backlog = zmalloc(server.repl_backlog_size);


### PR DESCRIPTION
动态修改从库的repl-backlog-size参数时，从库有可能会产生段错误，调用栈如下：

```
bin/redis-server *:6610 [cluster](replicationFeedRvsBacklog+0x5b)[0x43289b]
bin/redis-server *:6610 [cluster](readQueryFromClient+0x1b0)[0x42ce50]
bin/redis-server *:6610 [cluster](aeProcessEvents+0x13c)[0x41a88c]
bin/redis-server *:6610 [cluster](aeMain+0x2b)[0x41ab4b]
bin/redis-server *:6610 [cluster](main+0x2cd)[0x42422d]
/lib64/libc.so.6(__libc_start_main+0xfd)[0x30f221ed1d]
bin/redis-server *:6610 [cluster][0x419ea9]
```
复现步骤如下：
1.  在从库使用 `config` 命令调大 `repl-backlog-size` 参数
2. 主库不断写入数据
3. 等待从库出core

产生问题的原因：
`rvs_backlog` 与 `repl_backlog` 一样均使用 `server.repl_backlog_size` 作为大小分配内存。但是在动态修改`server.repl_backlog_size` 后并没有像  `repl_backlog` 一样重新对`rvs_backlog` 进行内存分配，从而导致了内存访问越界。

解决办法：
在动态修改 `server.repl_backlog_size`  命令时，同时对`rvs_backlog` 进行 `resize` 即可